### PR TITLE
Directly deleting Tar

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"bcrypt": "^6.0.0",
 		"react-icons": "^5.6.0",
 		"react-router-dom": "^7.14.1",
-		"tar": "^7.5.13"
 	},
 	"prettier": {
 		"singleQuote": true,


### PR DESCRIPTION
Repo is compromised, Deleting tar dependency and any package-lock tar files.